### PR TITLE
sort windows array before adding hint

### DIFF
--- a/extensions/hints/init.lua
+++ b/extensions/hints/init.lua
@@ -201,6 +201,13 @@ end
 function hints.windowHints(windows, callback, allowNonStandard)
 
   windows = windows or window.allWindows()
+  table.sort(windows, function(w1, w2)
+    if (w1:id() == nil or w2:id() == nil) then 
+      return false; 
+    end 
+    return w1:id() < w2:id();
+  end)
+
   selectionCallback = callback
 
   if (modalKey == nil) then


### PR DESCRIPTION
by sorting, the same hint character will be assigned to the same windows most of time, that will make window switching using hint characters easier
